### PR TITLE
header: use MergeSat

### DIFF
--- a/minisat/core/BoundedQueue.h
+++ b/minisat/core/BoundedQueue.h
@@ -20,8 +20,8 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 **************************************************************************************************/
 
 
-#ifndef BoundedQueue_h
-#define BoundedQueue_h
+#ifndef MergeSat_BoundedQueue_h
+#define MergeSat_BoundedQueue_h
 
 #include "mtl/Vec.h"
 

--- a/minisat/core/Constants.h
+++ b/minisat/core/Constants.h
@@ -19,6 +19,9 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **************************************************************************************************/
 
+#ifndef MergeSat_Constants_h
+#define MergeSat_Constants_h
+
 #define DYNAMICNBLEVEL
 #define CONSTANTREMOVECLAUSE
 #define UPDATEVARACTIVITY
@@ -29,3 +32,5 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 
 // Constants for restarts
 #define LOWER_BOUND_FOR_BLOCKING_RESTART 10000
+
+#endif

--- a/minisat/core/Dimacs.h
+++ b/minisat/core/Dimacs.h
@@ -18,8 +18,8 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **************************************************************************************************/
 
-#ifndef Minisat_Dimacs_h
-#define Minisat_Dimacs_h
+#ifndef MergeSat_Dimacs_h
+#define MergeSat_Dimacs_h
 
 #include <stdio.h>
 

--- a/minisat/core/Solver.h
+++ b/minisat/core/Solver.h
@@ -28,8 +28,8 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **************************************************************************************************/
 
-#ifndef Minisat_Solver_h
-#define Minisat_Solver_h
+#ifndef MergeSat_Solver_h
+#define MergeSat_Solver_h
 
 #define ANTI_EXPLORATION
 #define BIN_DRUP

--- a/minisat/core/SolverTypes.h
+++ b/minisat/core/SolverTypes.h
@@ -29,8 +29,8 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 **************************************************************************************************/
 
 
-#ifndef Minisat_SolverTypes_h
-#define Minisat_SolverTypes_h
+#ifndef MergeSat_SolverTypes_h
+#define MergeSat_SolverTypes_h
 
 #include <assert.h>
 

--- a/minisat/mtl/Alg.h
+++ b/minisat/mtl/Alg.h
@@ -18,8 +18,8 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **************************************************************************************************/
 
-#ifndef Minisat_Alg_h
-#define Minisat_Alg_h
+#ifndef MergeSat_Alg_h
+#define MergeSat_Alg_h
 
 #include "mtl/Vec.h"
 

--- a/minisat/mtl/Alloc.h
+++ b/minisat/mtl/Alloc.h
@@ -18,8 +18,8 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 **************************************************************************************************/
 
 
-#ifndef Minisat_Alloc_h
-#define Minisat_Alloc_h
+#ifndef MergeSat_Alloc_h
+#define MergeSat_Alloc_h
 
 #include "mtl/Vec.h"
 #include "mtl/XAlloc.h"

--- a/minisat/mtl/Heap.h
+++ b/minisat/mtl/Heap.h
@@ -18,8 +18,8 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **************************************************************************************************/
 
-#ifndef Minisat_Heap_h
-#define Minisat_Heap_h
+#ifndef MergeSat_Heap_h
+#define MergeSat_Heap_h
 
 #include "mtl/Vec.h"
 

--- a/minisat/mtl/IntTypes.h
+++ b/minisat/mtl/IntTypes.h
@@ -17,8 +17,8 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **************************************************************************************************/
 
-#ifndef Minisat_IntTypes_h
-#define Minisat_IntTypes_h
+#ifndef MergeSat_IntTypes_h
+#define MergeSat_IntTypes_h
 
 #ifdef __sun
 // Not sure if there are newer versions that support C99 headers. The

--- a/minisat/mtl/Map.h
+++ b/minisat/mtl/Map.h
@@ -17,8 +17,8 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **************************************************************************************************/
 
-#ifndef Minisat_Map_h
-#define Minisat_Map_h
+#ifndef MergeSat_Map_h
+#define MergeSat_Map_h
 
 #include "mtl/IntTypes.h"
 #include "mtl/Vec.h"

--- a/minisat/mtl/Queue.h
+++ b/minisat/mtl/Queue.h
@@ -18,8 +18,8 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **************************************************************************************************/
 
-#ifndef Minisat_Queue_h
-#define Minisat_Queue_h
+#ifndef MergeSat_Queue_h
+#define MergeSat_Queue_h
 
 #include "mtl/Vec.h"
 

--- a/minisat/mtl/Sort.h
+++ b/minisat/mtl/Sort.h
@@ -18,8 +18,8 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **************************************************************************************************/
 
-#ifndef Minisat_Sort_h
-#define Minisat_Sort_h
+#ifndef MergeSat_Sort_h
+#define MergeSat_Sort_h
 
 #include "mtl/Vec.h"
 #include <cstring> // for memcpy

--- a/minisat/mtl/Vec.h
+++ b/minisat/mtl/Vec.h
@@ -18,8 +18,8 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **************************************************************************************************/
 
-#ifndef Minisat_Vec_h
-#define Minisat_Vec_h
+#ifndef MergeSat_Vec_h
+#define MergeSat_Vec_h
 
 #include <assert.h>
 #include <new>

--- a/minisat/mtl/XAlloc.h
+++ b/minisat/mtl/XAlloc.h
@@ -18,8 +18,8 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 **************************************************************************************************/
 
 
-#ifndef Minisat_XAlloc_h
-#define Minisat_XAlloc_h
+#ifndef MergeSat_XAlloc_h
+#define MergeSat_XAlloc_h
 
 #include <errno.h>
 #include <stdlib.h>

--- a/minisat/simp/SimpSolver.h
+++ b/minisat/simp/SimpSolver.h
@@ -28,8 +28,8 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **************************************************************************************************/
 
-#ifndef Minisat_SimpSolver_h
-#define Minisat_SimpSolver_h
+#ifndef MergeSat_SimpSolver_h
+#define MergeSat_SimpSolver_h
 
 #include "core/Solver.h"
 #include "mtl/Queue.h"

--- a/minisat/utils/Options.h
+++ b/minisat/utils/Options.h
@@ -17,8 +17,8 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **************************************************************************************************/
 
-#ifndef Minisat_Options_h
-#define Minisat_Options_h
+#ifndef MergeSat_Options_h
+#define MergeSat_Options_h
 
 #include <math.h>
 #include <stdio.h>

--- a/minisat/utils/ParseUtils.h
+++ b/minisat/utils/ParseUtils.h
@@ -18,8 +18,8 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **************************************************************************************************/
 
-#ifndef Minisat_ParseUtils_h
-#define Minisat_ParseUtils_h
+#ifndef MergeSat_ParseUtils_h
+#define MergeSat_ParseUtils_h
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/minisat/utils/System.h
+++ b/minisat/utils/System.h
@@ -18,8 +18,8 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **************************************************************************************************/
 
-#ifndef Minisat_System_h
-#define Minisat_System_h
+#ifndef MergeSat_System_h
+#define MergeSat_System_h
 
 #if defined(__linux__)
 #include <fpu_control.h>


### PR DESCRIPTION
To be able to link a given tool to MergeSat and MiniSat at the same
time, make sure the header use different protection. Otherwise, a header
from one solver might be blocked due to the other header.

Signed-off-by: Norbert Manthey <nmanthey@conp-solutions.com>