### PR TITLE
decision: fix toggling heaps

### DIFF
--- a/minisat/core/Solver.cc
+++ b/minisat/core/Solver.cc
@@ -2237,6 +2237,7 @@ lbool Solver::solve_()
         if (switch_mode) {
             switch_mode = false;
             VSIDS = !VSIDS;
+            toggle_decision_heuristic(VSIDS); // switch to VSIDS
             if (verbosity >= 1) {
                 if (VSIDS) {
                     printf("c Switched to VSIDS.\n");
@@ -2244,9 +2245,6 @@ lbool Solver::solve_()
                     printf("c Switched to LRB/DISTANCE.\n");
                 }
             }
-
-            toggle_decision_heuristic(true);
-
             fflush(stdout);
         }
     }


### PR DESCRIPTION
Until now, we always moved heaps to VSIDS, independently of which heap
is actually used for picking decision variables. In the worst case, this
results in the solver reporting SAT for unsatisfiable formulas, namely
in combination with partial restarts, where the decision level is not
zero and there are pending assigned variables.

Fixes: 7404f17 (decision: toggle more stable)

Signed-off-by: Norbert Manthey <nmanthey@conp-solutions.com>