### PR TITLE
UP,enqueue: ask for level parameter

### DIFF
--- a/minisat/core/Solver.cc
+++ b/minisat/core/Solver.cc
@@ -591,7 +591,7 @@ bool Solver::simplifyLearnt(vec<CRef> &target_learnts, bool is_tier2)
 
                 if (c.size() == 1) {
                     // when unit clause occur, enqueue and propagate
-                    uncheckedEnqueue(c[0]);
+                    uncheckedEnqueue(c[0], 0);
                     if (propagate() != CRef_Undef) {
                         ok = false;
                         return false;
@@ -763,7 +763,7 @@ bool Solver::addClause_(vec<Lit> &ps)
     if (ps.size() == 0)
         return ok = false;
     else if (ps.size() == 1) {
-        uncheckedEnqueue(ps[0]);
+        uncheckedEnqueue(ps[0], 0);
         return ok = (propagate() == CRef_Undef);
     } else {
         CRef cr = ca.alloc(ps, false);
@@ -1826,7 +1826,7 @@ CRef Solver::propagateLits(vec<Lit> &lits)
         lit = lits[i];
         if (value(lit) == l_Undef) {
             newDecisionLevel();
-            uncheckedEnqueue(lit);
+            uncheckedEnqueue(lit, decisionLevel());
             CRef confl = propagate();
             if (confl != CRef_Undef) {
                 return confl;
@@ -1998,7 +1998,7 @@ lbool Solver::search(int &nof_conflicts)
             }
 
             if (learnt_clause.size() == 1) {
-                uncheckedEnqueue(learnt_clause[0]);
+                uncheckedEnqueue(learnt_clause[0], decisionLevel());
             } else {
                 CRef cr = ca.alloc(learnt_clause, true);
                 ca[cr].set_lbd(lbd);

--- a/minisat/core/Solver.h
+++ b/minisat/core/Solver.h
@@ -444,7 +444,7 @@ class Solver
     void insertVarOrder(Var x); // Insert a variable in the decision order priority queue.
     Lit pickBranchLit();        // Return the next decision variable.
     void newDecisionLevel();    // Begins a new decision level.
-    void uncheckedEnqueue(Lit p, int level = 0, CRef from = CRef_Undef); // Enqueue a literal. Assumes value of literal is undefined.
+    void uncheckedEnqueue(Lit p, int level, CRef from = CRef_Undef); // Enqueue a literal. Assumes value of literal is undefined.
     bool enqueue(Lit p, CRef from = CRef_Undef); // Test if fact 'p' contradicts current state, enqueue otherwise.
     CRef propagate();                            // Perform unit propagation. Returns possibly conflicting clause.
     void cancelUntil(int level);                 // Backtrack until a certain level.

--- a/minisat/simp/SimpSolver.cc
+++ b/minisat/simp/SimpSolver.cc
@@ -386,7 +386,7 @@ bool SimpSolver::implied(const vec<Lit> &c)
             return true;
         } else if (value(c[i]) != l_False) {
             assert(value(c[i]) == l_Undef);
-            uncheckedEnqueue(~c[i]);
+            uncheckedEnqueue(~c[i], decisionLevel());
         }
 
     bool result = propagate() != CRef_Undef;
@@ -481,7 +481,7 @@ bool SimpSolver::asymm(Var v, CRef cr)
     Lit l = lit_Undef;
     for (int i = 0; i < c.size(); i++)
         if (var(c[i]) != v) {
-            if (value(c[i]) != l_False) uncheckedEnqueue(~c[i]);
+            if (value(c[i]) != l_False) uncheckedEnqueue(~c[i], 0);
         } else
             l = c[i];
 


### PR DESCRIPTION
When using the enqueue function, the default decision level to put
literals in is 0. To make sure we actually want to set this level, make
the level parameter non-default, i.e. enforce setting the required level
explicitly.

While running through the code, we spotted places where 0 was used
wrongly. Now, the solver use the enqueue function as expected.

Signed-off-by: Norbert Manthey <nmanthey@conp-solutions.com>