### PR TITLE
UP,watches: lazily add watches

### DIFF
--- a/minisat/core/Solver.h
+++ b/minisat/core/Solver.h
@@ -313,6 +313,14 @@ class Solver
         bool bOnlyOneLitFromHighest;
     };
 
+    struct watchItem {
+        Watcher w;
+        Lit l;
+        watchItem(const Watcher &_w, const Lit _l) : w(_w), l(_l) {}
+    };
+    vec<watchItem> lazySATwatch;
+
+
     // Solver state:
     //
     bool ok;           // If FALSE, the constraints are already unsatisfiable. No part of the solver state may be used!


### PR DESCRIPTION
Watched clauses, that have a satisfiable literal that can be watched,
are typically moved to the other watch list eagerly. This might, in
turn, result in loading the watch list, polluting the cache as well as
TLB. To reduce this pollution, we maintain an additional list to later
run the maintanance, i.e. we update these watch lists lazily. The effect
is that these clauses are touched less frequently during one
propagation. As they are added in order, the steps of the search are not
touched.

This idea can be extended. As long as we propagate without a restart, or
a conflict that results in backtracking, we could keep the clauses in
the additional data structure, and only add them back, in case we jump
back. This allows for further savings. As this idea is too complex for
an initial test, we focus on the simple variant first.

Signed-off-by: Norbert Manthey <nmanthey@conp-solutions.com>