### PR TITLE
Specify variable size explicitly in format strings

### DIFF
--- a/minisat/core/Solver.cc
+++ b/minisat/core/Solver.cc
@@ -2618,7 +2618,7 @@ lbool Solver::search(int &nof_conflicts)
     // simplify
     //
     if (lcm && conflicts >= curSimplify * nbconfbeforesimplify) {
-        TRACE(printf("c ### simplifyAll on conflict : %ld\n", conflicts);)
+        TRACE(printf("c ### simplifyAll on conflict : %" PRId64 "\n", conflicts);)
         if (verbosity >= 1)
             printf("c schedule LCM with: nbClauses: %d, nbLearnts_core: %d, nbLearnts_tier2: %d, nbLearnts_local: %d, "
                    "nbLearnts: %d\n",
@@ -2659,7 +2659,7 @@ lbool Solver::search(int &nof_conflicts)
 
             conflicts++;
             nof_conflicts--;
-            TRACE(printf("c hit conflict %ld\n", conflicts);)
+            TRACE(printf("c hit conflict %" PRId64 "\n", conflicts);)
             if (conflicts == 100000 && learnts_core.size() < 100) core_lbd_cut = 5;
             ConflictData data = FindConflictLevel(confl);
             if (data.nHighestLevel == 0) return l_False;
@@ -3295,7 +3295,7 @@ bool Solver::inprocessing()
         int Z = 0, i, j, k, l = -1, p;
 
         if (verbosity > 0)
-            printf("c inprocessing simplify at try %ld, next limit: %ld\n", inprocess_attempts, inprocess_next_lim);
+            printf("c inprocessing simplify at try %" PRId64 ", next limit: %" PRId64 "\n", inprocess_attempts, inprocess_next_lim);
         // fill occurrence data structure
         O.resize(2 * nVars());
 
@@ -3520,16 +3520,16 @@ void Solver::printStats()
            starts, restart.partialRestarts, restart.savedDecisions, restart.savedPropagations,
            ((double)restart.savedPropagations * 100.0) / (double)propagations);
     printf("c polarity              : %d pos, %d neg\n", posMissingInSome, negMissingInSome);
-    printf("c LCM                   : %lu runs, %lu Ctried, %lu Cshrinked (%lu known duplicates), %lu Ldeleted, %lu "
-           "Lrev-deleted\n",
+    printf("c LCM                   : %" PRIu64 " runs, %" PRIu64 " Ctried, %" PRIu64 " Cshrinked (%" PRIu64
+           " known duplicates), %" PRIu64 " Ldeleted, %" PRIu64 " Lrev-deleted\n",
            nbSimplifyAll, LCM_total_tries, LCM_successful_tries, nr_lcm_duplicates, LCM_dropped_lits, LCM_dropped_reverse);
-    printf("c Inprocessing          : %lu subsumed, %lu dropped lits, %lu attempts, %lu mems\n", inprocessing_C,
-           inprocessing_L, inprocessings, inprocess_mems);
-    printf("c Stats:                : %lf solve, %lu steps, %lf simp, %lu steps, %d var, budget: %d\n", statistics.solveSeconds,
-           statistics.solveSteps, statistics.simpSeconds, statistics.simpSteps, nVars(), withinBudget());
-    printf("c backup trail: stored: %lu used successfully: %lu\n", backuped_trail_lits, used_backup_lits);
-    printf("c accesses:               clauses: %lu occurrences: %lu sum: %lu\n", counter_access.clause(),
-           counter_access.occurrence(), counter_access.sum());
+    printf("c Inprocessing          : %" PRIu64 " subsumed, %" PRIu64 " dropped lits, %" PRIu64 " attempts, %" PRIu64 " mems\n",
+           inprocessing_C, inprocessing_L, inprocessings, inprocess_mems);
+    printf("c Stats:                : %lf solve, %" PRIu64 " steps, %lf simp, %" PRIu64 " steps, %d var, budget: %d\n",
+           statistics.solveSeconds, statistics.solveSteps, statistics.simpSeconds, statistics.simpSteps, nVars(), withinBudget());
+    printf("c backup trail: stored: %" PRIu64 " used successfully: %" PRIu64 "\n", backuped_trail_lits, used_backup_lits);
+    printf("c accesses:               clauses: %" PRIu64 " occurrences: %" PRIu64 " sum: %" PRIu64 "\n",
+           counter_access.clause(), counter_access.occurrence(), counter_access.sum());
     printf("c CPU time              : %g s\n", cpu_time);
 }
 

--- a/minisat/simp/Main.cc
+++ b/minisat/simp/Main.cc
@@ -240,7 +240,7 @@ int main(int argc, char **argv)
         double simplified_time = cpuTime();
         if (S.verbosity > 0) {
             printf("c |  Simplification time:  %12.2f s                                       |\n", simplified_time - parsed_time);
-            printf("c |  Simplification steps: %12ld                                         |\n", S.counter_sum());
+            printf("c |  Simplification steps: %12" PRId64 "                                         |\n", S.counter_sum());
             printf("c |                                                                             |\n");
         }
 

--- a/minisat/utils/Options.h
+++ b/minisat/utils/Options.h
@@ -630,10 +630,10 @@ class Int64Option : public Option
     void checkValueOrExit(int64_t tmp)
     {
         if (tmp > range.end) {
-            fprintf(stderr, "ERROR! value <%ld> is too large for option \"%s\".\n", tmp, name);
+            fprintf(stderr, "ERROR! value <%" PRId64 "> is too large for option \"%s\".\n", tmp, name);
             exit(1);
         } else if (tmp < range.begin) {
-            fprintf(stderr, "ERROR! value <%ld> is too small for option \"%s\".\n", tmp, name);
+            fprintf(stderr, "ERROR! value <%" PRId64 "> is too small for option \"%s\".\n", tmp, name);
             exit(1);
         }
     }
@@ -734,23 +734,25 @@ class Int64Option : public Option
                 if (i != 0) {
                     fprintf(pcsFile, ",");
                 }
-                fprintf(pcsFile, "%ld", values[i]);
+                fprintf(pcsFile, "%" PRId64, values[i]);
             }
-            fprintf(pcsFile, "} [%ld]    # %s\n", value, description);
+            fprintf(pcsFile, "} [%" PRId64 "]    # %s\n", value, description);
         } else {
             if ((range.end - range.begin <= 16 && range.end - range.begin > 0 && range.end != INT32_MAX) ||
                 (range.begin <= 0 && range.end >= 0)) {
                 if (range.end - range.begin <= 16 && range.end - range.begin > 0) { // print all values if the difference is really small
-                    fprintf(pcsFile, "%s  {%ld", name, range.begin);
+                    fprintf(pcsFile, "%s  {%" PRId64, name, range.begin);
                     for (int64_t i = range.begin + 1; i <= range.end; ++i) {
-                        fprintf(pcsFile, ",%ld", i);
+                        fprintf(pcsFile, ",%" PRId64, i);
                     }
-                    fprintf(pcsFile, "} [%ld]    # %s\n", value, description);
+                    fprintf(pcsFile, "} [%" PRId64 "]    # %s\n", value, description);
                 } else {
-                    fprintf(pcsFile, "%s  [%ld,%ld] [%ld]i    # %s\n", name, range.begin, range.end, value, description);
+                    fprintf(pcsFile, "%s  [%" PRId64 ",%" PRId64 "] [%" PRId64 "]i    # %s\n", name, range.begin,
+                            range.end, value, description);
                 }
             } else {
-                fprintf(pcsFile, "%s  [%ld,%ld] [%ld]il   # %s\n", name, range.begin, range.end, value, description);
+                fprintf(pcsFile, "%s  [%" PRId64 ",%" PRId64 "] [%" PRId64 "]il   # %s\n", name, range.begin, range.end,
+                        value, description);
             }
         }
     }
@@ -768,8 +770,8 @@ class Int64Option : public Option
             for (size_t i = 0; i < values.size(); ++i) {
                 if (values[i] == defaultValue) {
                     continue;
-                }                                         // do not print default value
-                snprintf(buffer, size, "%ld", values[i]); // convert value
+                }                                              // do not print default value
+                snprintf(buffer, size, "%" PRId64, values[i]); // convert value
                 const int sl = strlen(buffer);
                 size = size - strlen(buffer) - 1; // store new size
                 if (i + 1 < values.size() && values[i + 1] != defaultValue) {
@@ -782,8 +784,8 @@ class Int64Option : public Option
             for (int64_t i = range.begin; i <= range.end; ++i) {
                 if (i == defaultValue) {
                     continue;
-                }                                 // do not print default value
-                snprintf(buffer, size, "%ld", i); // convert value
+                }                                      // do not print default value
+                snprintf(buffer, size, "%" PRId64, i); // convert value
                 const int sl = strlen(buffer);
                 size = size - strlen(buffer) - 1; // store new size
                 if (i != range.end && i + 1 != defaultValue) {


### PR DESCRIPTION
The current implementation uses `%ld` and `%lu` in format strings for `int64_t` and `uint64_t`, but that doesn't fit to 32-bit environment, such as wasm32, as `long` is also 32-bit.
Can I replace them with explicit size ones?